### PR TITLE
Add requirements.txt for installing dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.cache
+library.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # spotibrarian
 Tag-based library manager for Spotify
+
+# development
+To install dependencies run: `python -m pip install -r requirements.txt`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+certifi==2020.12.5
+chardet==4.0.0
+idna==2.10
+numpy==1.20.1
+pandas==1.2.3
+PyQt5==5.15.4
+PyQt5-Qt5==5.15.2
+PyQt5-sip==12.8.1
+python-dateutil==2.8.1
+pytz==2021.1
+requests==2.25.1
+six==1.15.0
+spotipy==2.17.1
+urllib3==1.26.4


### PR DESCRIPTION
These changes add a requirements.txt file to manage your dependencies and when someone clones the repo they can run the install command on the file to download everything they need to run main.py. Also adding .gitignore bcuz wow