### PR TITLE
Add dotenv to load client secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .cache
+.env
 library.json

--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@ Tag-based library manager for Spotify
 
 # development
 To install dependencies run: `python -m pip install -r requirements.txt`
+
+## client secret
+After cloning the repository create a .env file in the root directory with a CLIENT_SECRET key set to your spotify client secret key. You can base this .env file off of the env-sample file.

--- a/env-sample
+++ b/env-sample
@@ -1,0 +1,1 @@
+CLIENT_SECRET="ur super secret client secret go here"

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import os
 import pandas as pd
 import spotipy
 import sys
+from dotenv import load_dotenv
 from PyQt5 import QtWidgets as qtw, QtGui as qtg, QtCore as qtc, uic
 from spotipy.oauth2 import SpotifyOAuth
 
@@ -31,7 +32,7 @@ class Spotibrarian:
         self._ui = uic.loadUi('ui/main.ui')
         scope = 'user-library-read playlist-modify-public'
         cid = "72e180d9f7a54590a1214f158cb264b5"
-        cs = "20f168e6f0b94f098c495f6bca4df90d"
+        cs = os.getenv("CLIENT_SECRET")
         self._sp = spotipy.Spotify(auth_manager=SpotifyOAuth(scope=scope, client_id=cid, client_secret=cs,
                                                              redirect_uri="http://localhost:8888/callback"))
         self._init_library()
@@ -184,6 +185,7 @@ class Spotibrarian:
 
 
 if __name__ == "__main__":
+    load_dotenv()
     app = qtw.QApplication(sys.argv)  # Create an instance of QtWidgets.QApplication
     window = Spotibrarian()  # Create an instance of our class
     app.exec_()  # Start the application

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 certifi==2020.12.5
 chardet==4.0.0
+python-dotenv==0.15.0
 idna==2.10
 numpy==1.20.1
 pandas==1.2.3


### PR DESCRIPTION
Add dotenv which will load environment variables specified in a .env file so that os can get them at runtime. Also adds an env-sample file which gives people an idea of what their local .env file should look like since committing the real .env is a no-no.